### PR TITLE
Added WORKDIR to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ ENV host:logger:consoleLoggingMode=always
 
 COPY . /home/site/wwwroot
 
-RUN cd /home/site/wwwroot && pip install -r requirements.txt
+WORKDIR /home/site/wwwroot
+
+RUN pip install -r requirements.txt


### PR DESCRIPTION
Currently building the docker image and executing the commands mentioned in the README would give the following error:

```
Unhandled Exception: System.UnauthorizedAccessException: Access to the path '/proc/1/map_files' is denied. ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.Enumeration.FileSystemEnumerator`1.FindNextEntry()
   at System.IO.Enumeration.FileSystemEnumerator`1.MoveNext()
   at System.IO.FileSystemWatcher.RunningInstance.AddDirectoryWatchUnlocked(WatchedDirectory parent, String directoryName)
   at System.IO.FileSystemWatcher.RunningInstance.AddDirectoryWatchUnlocked(WatchedDirectory parent, String directoryName)
   at System.IO.FileSystemWatcher.RunningInstance.AddDirectoryWatchUnlocked(WatchedDirectory parent, String directoryName)
   at System.IO.FileSystemWatcher.RunningInstance.AddDirectoryWatchUnlocked(WatchedDirectory parent, String directoryName)
   at System.IO.FileSystemWatcher.RunningInstance..ctor(FileSystemWatcher watcher, SafeFileHandle inotifyHandle, String directoryPath, Boolean includeSubdirectories, NotifyFilters notifyFilters, CancellationToken cancellationToken)
   at System.IO.FileSystemWatcher.StartRaisingEvents()
   at System.IO.FileSystemWatcher.StartRaisingEventsIfNotDisposed()
   at System.IO.FileSystemWatcher.set_EnableRaisingEvents(Boolean value)
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.TryEnableFileSystemWatcher()
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.CreateFileChangeToken(String filter)
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider.Watch(String filter)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider.<.ctor>b__0_0()
   at Microsoft.Extensions.Primitives.ChangeToken.OnChange(Func`1 changeTokenProducer, Action changeTokenConsumer)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider..ctor(FileConfigurationSource source)
   at Microsoft.Extensions.Configuration.Json.JsonConfigurationSource.Build(IConfigurationBuilder builder)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.BuildCommonServices(AggregateException& hostingStartupErrors)
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build()
   at Microsoft.Azure.WebJobs.Script.WebHost.Program.BuildWebHost(String[] args) in /azure-functions-host-26390c79fe40b04617bc7fc3a9add054dec27310/src/WebJobs.Script.WebHost/Program.cs:line 37
   at Microsoft.Azure.WebJobs.Script.WebHost.Program.Main(String[] args) in /azure-functions-host-26390c79fe40b04617bc7fc3a9add054dec27310/src/WebJobs.Script.WebHost/Program.cs:line 22
/azure-functions-host/run-host.sh: line 8:   439 Aborted                 (core dumped) dotnet /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll
process exited with 134
restarting host process
```

The [workaround for this issue](https://github.com/dotnet/dotnet-docker/issues/644) is to add `WORKDIR` to Dockerfile.